### PR TITLE
fix: TypeScript v6 対応のため tsconfig を修正

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "module": "commonjs",
-    "moduleResolution": "Node",
+    "module": "node16",
+    "moduleResolution": "node16",
     "lib": ["ESNext", "esnext.AsyncIterable"],
     "outDir": "./dist",
+    "rootDir": "./src",
     "removeComments": true,
     "esModuleInterop": true,
     "allowJs": true,
@@ -22,8 +23,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
     "newLine": "LF"
   },
-  "include": ["src/**/*", "api/**/*"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## 概要

TypeScript v6 (`6.0.3`) へのアップデート（[PR #824](https://github.com/tomacheese/vrcx-web-server/pull/824)）に伴い、`tsconfig.json` を修正します。

## 背景

Renovate が作成した PR #824 で TypeScript が `5.9.3` → `6.0.3` に更新されましたが、TypeScript v6 では以下のエラーが発生し CI が失敗しています。

- **TS5107**: `moduleResolution=node10` (`Node` の別名) が非推奨
- **TS5011**: `outDir` 設定時に `rootDir` が未設定
- **TS5101**: `baseUrl` が非推奨

## 変更内容

| 変更箇所 | 変更前 | 変更後 | 理由 |
|---|---|---|---|
| `module` | `commonjs` | `node16` | `moduleResolution: node16` に合わせる必要があるため |
| `moduleResolution` | `Node` | `node16` | 非推奨の `node`/`node10` を解消 |
| `rootDir` | (未設定) | `./src` | TS5011 解消。`outDir` 設定時は明示的に指定が必要 |
| `baseUrl` | `.` | (削除) | TS5101 解消。`paths` も未使用のため削除 |
| `include` | `["src/**/*", "api/**/*"]` | `["src/**/*"]` | `api/` ディレクトリが存在しないため削除 |

## 動作確認

- TypeScript 5.9.3 (現在の master): ビルド・lint すべて通過
- TypeScript 6.0.3 (Renovate PR 適用後): ビルド・lint すべて通過
- 出力形式: CommonJS (`"use strict"` + `require()`) を維持

## 関連

- Closes #824 (このブランチが master にマージされると、Renovate の rebase で #824 の CI が通るようになります)

🤖 Generated with [Claude Code](https://claude.com/claude-code)