### PR TITLE
fix(lint): eslint-config 更新で追加される unicorn ルール違反を解消

### DIFF
--- a/src/endpoints/root.ts
+++ b/src/endpoints/root.ts
@@ -28,7 +28,7 @@ export class RootRouter extends BaseRouter {
       'script.js': 'application/javascript',
     }
 
-    if (mapping[path]) {
+    if (Object.hasOwn(mapping, path)) {
       reply.header('Content-Type', mapping[path])
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ async function main() {
 
   const app = await buildApp()
   const host = ENV.API_HOST
-  const port = ENV.API_PORT ? Number.parseInt(ENV.API_PORT, 10) : 8000
+  const port = ENV.API_PORT ? Number(ENV.API_PORT) : 8000
   app.listen({ host, port }, (error, address) => {
     if (error) {
       logger.error('❌ Fastify.listen error', error)

--- a/view/script.js
+++ b/view/script.js
@@ -115,7 +115,8 @@ const app = createApp({
               .toLowerCase()
               .includes(this.feed.search.toLowerCase())
           })
-      } else if (this.tab === 2) {
+      }
+      if (this.tab === 2) {
         return this.gamelog.items
           .filter((item) => {
             return this.gamelog.selectTypes.includes(item.type)
@@ -162,12 +163,11 @@ const app = createApp({
         this.fetchBioFeed(page, limit),
         this.fetchAvatarFeed(page, limit),
         this.fetchOnlineOfflineFeed(page, limit),
-      ]).then(() => {
-        this.feed.loadingItems.sort((a, b) => {
-          return b.created_at - a.created_at
-        })
-        this.feed.items = this.feed.loadingItems
+      ])
+      this.feed.loadingItems.sort((a, b) => {
+        return b.created_at - a.created_at
       })
+      this.feed.items = this.feed.loadingItems
     },
     async fetchGpsFeed(page, limit) {
       const type = 'gps'
@@ -281,12 +281,11 @@ const app = createApp({
         this.fetchJoinLeaveLog(page, limit),
         this.fetchVideoPlayLog(page, limit),
         this.fetchEventLog(page, limit),
-      ]).then(() => {
-        this.gamelog.loadingItems.sort((a, b) => {
-          return b.created_at - a.created_at
-        })
-        this.gamelog.items = this.gamelog.loadingItems
+      ])
+      this.gamelog.loadingItems.sort((a, b) => {
+        return b.created_at - a.created_at
       })
+      this.gamelog.items = this.gamelog.loadingItems
     },
     async fetchLocationLog(page, limit) {
       const type = 'location'
@@ -374,13 +373,14 @@ const app = createApp({
     getWorldName(item) {
       if (item.world_name) {
         return item.world_name
-      } else if (item.location === 'private') {
-        return 'Private'
-      } else if (item.location === 'traveling') {
-        return 'Traveling'
-      } else {
-        return 'Unknown'
       }
+      if (item.location === 'private') {
+        return 'Private'
+      }
+      if (item.location === 'traveling') {
+        return 'Traveling'
+      }
+      return 'Unknown'
     },
     formatDate(date) {
       return date.toLocaleString('ja-JP', {


### PR DESCRIPTION
## 概要

Renovate PR #993（`@book000/eslint-config` 1.15.4 → 1.15.44）が `eslint-plugin-unicorn` の新しいルールを取り込んだことで、`lint:eslint` が既存コードに対して 6 件のエラーを検出し CI が失敗していました。本 PR はそれらのルール違反を修正し、CI を通るようにします。

## 修正内容

- `src/endpoints/root.ts`: `unicorn/no-computed-property-existence-check` — プロパティ存在チェックを `mapping[path]` から `Object.hasOwn(mapping, path)` に変更
- `src/main.ts`: `unicorn/prefer-number-coercion` — `Number.parseInt(ENV.API_PORT, 10)` を `Number(ENV.API_PORT)` に変更
- `view/script.js`: `unicorn/no-useless-else` x2 — `return` 直後の不要な `else` を削除
- `view/script.js`: `unicorn/prefer-await` x2 — `Promise.all(...).then(...)` を `await` を使った形に変更

いずれも挙動を変えないスタイル上の修正です。

## 検証

- `pnpm run lint`（prettier + eslint + tsc）が現行の `@book000/eslint-config@1.15.4` 環境で成功することを確認
- `@book000/eslint-config@1.15.44`（PR #993 の更新後バージョン）に一時的に切り替えても `pnpm run lint` が成功することを確認（本 PR には eslint-config 自体の更新は含めていません）
